### PR TITLE
Replace sanitize(val) with quote(val, col_definition)

### DIFF
--- a/lib/active_record_bulk_insert.rb
+++ b/lib/active_record_bulk_insert.rb
@@ -20,7 +20,7 @@ ActiveRecord::Base.class_eval do
     end
 
     values_sql = attrs.map do |record|
-      "(#{_resolve_record(record, options).map {|k, v| connection.quote v, column_for_attribute(k) }.join(', ')})"
+      "(#{_resolve_record(record, options).map {|k, v| connection.quote(v, try(:column_for_attribute, k)) }.join(', ')})"
     end.join(",")
 
     sql = <<-SQL

--- a/lib/active_record_bulk_insert.rb
+++ b/lib/active_record_bulk_insert.rb
@@ -20,7 +20,7 @@ ActiveRecord::Base.class_eval do
     end
 
     values_sql = attrs.map do |record|
-      "(#{_resolve_record(record, options).values.map { |r| sanitize(r) }.join(', ')})"
+      "(#{_resolve_record(record, options).map {|k, v| connection.quote v, column_for_attribute(k) }.join(', ')})"
     end.join(",")
 
     sql = <<-SQL


### PR DESCRIPTION
Non standard columns like Point, Hstore are not handled correctly using
ActiveRecord::Base.sanitize. For example sanitize of a Point gives
=> "'---\n- 77.086565\n- 28.455375\n'"

Instead use ActiveRecord::Base.connection.quote with the actual column
definition to correctly serialize the value for insertion. In the above
example usage of quote with the definition for the column will give:
=> "'(77.086565,28.455375)'"