### PR TITLE
Resolve rails 5 deprecation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,6 @@ before_install:
   - sudo sqlite3 -version
   - gem update bundler
 rvm:
-  - "1.9.3"
-  - "2.0.0"
-  - "2.1.0"
-  - "2.1.1"
-  - "2.1.9"
   - "2.2.5"
   - "2.3.1"
 script: bundle exec rspec spec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,28 +6,23 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (4.0.0)
-      activesupport (= 4.0.0)
-      builder (~> 3.1.0)
-    activerecord (4.0.0)
-      activemodel (= 4.0.0)
-      activerecord-deprecated_finders (~> 1.0.2)
-      activesupport (= 4.0.0)
-      arel (~> 4.0.0)
-    activerecord-deprecated_finders (1.0.3)
-    activesupport (4.0.0)
-      i18n (~> 0.6, >= 0.6.4)
-      minitest (~> 4.2)
-      multi_json (~> 1.3)
-      thread_safe (~> 0.1)
-      tzinfo (~> 0.3.37)
-    arel (4.0.2)
-    builder (3.1.4)
-    database_cleaner (1.0.1)
+    activemodel (5.0.0.1)
+      activesupport (= 5.0.0.1)
+    activerecord (5.0.0.1)
+      activemodel (= 5.0.0.1)
+      activesupport (= 5.0.0.1)
+      arel (~> 7.0)
+    activesupport (5.0.0.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    arel (7.1.4)
+    concurrent-ruby (1.0.2)
+    database_cleaner (1.5.3)
     diff-lcs (1.2.5)
-    i18n (0.6.9)
-    minitest (4.7.5)
-    multi_json (1.10.1)
+    i18n (0.7.0)
+    minitest (5.10.1)
     rspec (2.13.0)
       rspec-core (~> 2.13.0)
       rspec-expectations (~> 2.13.0)
@@ -37,16 +32,17 @@ GEM
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.13.1)
     sqlite3 (1.3.12)
-    thread_safe (0.3.4)
-    tzinfo (0.3.39)
+    thread_safe (0.3.5)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   active_record_bulk_insert!
-  activerecord (= 4.0.0)
-  database_cleaner (= 1.0.1)
+  activerecord
+  database_cleaner
   rspec (= 2.13.0)
   sqlite3
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    active_record_bulk_insert (1.0.2)
+    active_record_bulk_insert (1.1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -36,7 +36,7 @@ GEM
     rspec-expectations (2.13.0)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.13.1)
-    sqlite3 (1.3.7)
+    sqlite3 (1.3.12)
     thread_safe (0.3.4)
     tzinfo (0.3.39)
 
@@ -48,4 +48,7 @@ DEPENDENCIES
   activerecord (= 4.0.0)
   database_cleaner (= 1.0.1)
   rspec (= 2.13.0)
-  sqlite3 (= 1.3.7)
+  sqlite3
+
+BUNDLED WITH
+   1.13.6

--- a/active_record_bulk_insert.gemspec
+++ b/active_record_bulk_insert.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new do |gem|
   gem.require_path  = 'lib'
   gem.version       = "1.1.0"
 
-  gem.add_development_dependency("activerecord", "4.0.0")
-  gem.add_development_dependency("database_cleaner", "1.0.1")
+  gem.add_development_dependency("activerecord")
+  gem.add_development_dependency("database_cleaner")
   gem.add_development_dependency("rspec", "2.13.0")
   gem.add_development_dependency("sqlite3")
   gem.add_development_dependency("pg", "0.17.1") if ENV['benchmark']

--- a/active_record_bulk_insert.gemspec
+++ b/active_record_bulk_insert.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency("activerecord", "4.0.0")
   gem.add_development_dependency("database_cleaner", "1.0.1")
   gem.add_development_dependency("rspec", "2.13.0")
-  gem.add_development_dependency("sqlite3", "1.3.7")
+  gem.add_development_dependency("sqlite3")
   gem.add_development_dependency("pg", "0.17.1") if ENV['benchmark']
 end

--- a/lib/active_record_bulk_insert.rb
+++ b/lib/active_record_bulk_insert.rb
@@ -23,7 +23,12 @@ ActiveRecord::Base.class_eval do
     end
 
     values_sql = attrs.map do |record|
-      "(#{_resolve_record(record, options).map {|k, v| connection.quote(v, try(:column_for_attribute, k)) }.join(', ')})"
+      quoted = _resolve_record(record, options).map {|k, v|
+        column = try(:column_for_attribute, k)
+        v = connection.type_cast_from_column(column, v) if column
+        connection.quote(v)
+      }
+      "(#{quoted.join(', ')})"
     end.join(",")
 
     sql = <<-SQL

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,8 @@ ActiveRecord::Base.establish_connection(:adapter => "sqlite3", :database => ":me
 ActiveRecord::Migration.verbose = false
 ActiveRecord::Migrator.migrate("spec/support/migrations")
 
+I18n.config.enforce_available_locales = false
+
 RSpec.configure do |config|
   config.treat_symbols_as_metadata_keys_with_true_values = true
   config.order = "random"

--- a/spec/support/migrations/1_sample_record_migration.rb
+++ b/spec/support/migrations/1_sample_record_migration.rb
@@ -1,4 +1,4 @@
-class SampleRecordMigration < ActiveRecord::Migration
+class SampleRecordMigration < ActiveRecord::Migration[4.2]
   def change
     create_table :sample_records do |t|
       t.text "name"


### PR DESCRIPTION
Hello

I'm upgrading to Rails 5.
And it shows a lot of deprecation warnings.

    DEPRECATION WARNING: Passing a column to `quote` has been deprecated. It is only used for type casting, which should be handled elsewhere. See https://github.com/rails/arel/commit/6160bfbda1d1781c3b08a33ec4955f170e95be11 for more information.

Fixed this and few more.

Looks like `sqlite` frozen because of Travis, could not find version `3.7.15` on Arch Linux, updated to latest to run `rspec`. Please skip this change.  

Thanks for the gem!