### PR TITLE
Add validate_with option for using a custom validator.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,17 @@ User.bulk_insert(users, :validate => true)
 ```
 *The return value is a list of invalid records*
 
+### Validate with a custom validator
+
+```ruby
+users = [{:username => "foo", :firstname => "Foo", :lastname => "Bar", :age => 31},
+         {:username => "j.doe", :firstname => "John", :lastname => "Doe", :age => 57},
+         {:firstname => "John", :lastname => "Doe", :age => 57}]
+User.bulk_insert(users, :validate_with => Proc.new { |user| !user[:username].blank? })
+# => [{:firstname => "John", :lastname => "Doe", :age => 57}]
+```
+*The return value is a list of invalid records*
+
 ### Provide your own primary keys
 
 ```ruby

--- a/lib/active_record_bulk_insert.rb
+++ b/lib/active_record_bulk_insert.rb
@@ -18,8 +18,9 @@ ActiveRecord::Base.class_eval do
     attributes = _resolve_record(attrs.first, options).keys.join(", ")
 
     invalid = []
-    if options.fetch(:validate, false)
-      attrs, invalid = attrs.partition { |record| _validate(record) }
+    if options.fetch(:validate, false) || options.fetch(:validate_with, false)
+      _validator = options.fetch(:validate_with, self.method(:_validate))
+      attrs, invalid = attrs.partition { |record| _validator.call(record) }
     end
 
     values_sql = attrs.map do |record|

--- a/spec/sample_record_spec.rb
+++ b/spec/sample_record_spec.rb
@@ -89,6 +89,25 @@ describe SampleRecord do
         invalid_records = SampleRecord.bulk_insert(records, :validate => true, :disable_timestamps => true)
         invalid_records.should == [{:age => 30, :name => ""}]
       end
+
+      it "validates with a custom validator if ':validate_with' is specified" do
+        records = [{:age => 30, :name => "Bar"}, {:age => 29, :name => "Foo"}]
+        validator = Proc.new { |record| record[:name] != "Foo" }
+
+        invalid_records = SampleRecord.bulk_insert(records, :validate_with => validator)
+
+        invalid_records.should == [{:age => 29, :name => "Foo"}]
+      end
+
+      it "validates with the custom validator when both ':validate' and ':validate_with' are specified" do
+        SampleRecord.send(:validates, :name, :presence => true)
+        records = [{:age => 30, :name => ""}, {:age => 29, :name => "Foo"}]
+        validator = Proc.new { |record| record[:name] != "Foo" }
+
+        invalid_records = SampleRecord.bulk_insert(records, :validate => true, :validate_with => validator)
+
+        invalid_records.should == [{:age => 29, :name => "Foo"}]
+      end
     end
 
     context "timestamps" do


### PR DESCRIPTION
This PR adds a `validate_with` option for providing a custom validator. This is useful in cases where it is undesirable to instantiate AR objects for each record but validation is still needed.