### PR TITLE
lookup column by key instead of value

### DIFF
--- a/lib/active_record_bulk_insert.rb
+++ b/lib/active_record_bulk_insert.rb
@@ -43,7 +43,7 @@ ActiveRecord::Base.class_eval do
   def self._bulk_insert_quote(key, value)
     case ActiveRecord::VERSION::MAJOR
     when 5
-      column = try(:column_for_attribute, value)
+      column = try(:column_for_attribute, key)
       value = connection.type_cast_from_column(column, value) if column
       connection.quote(value)
     when 4


### PR DESCRIPTION
In the ActiveRecord 5 codepath, the column is being looked up with `value` rather than `key`. This PR uses `key` to do the lookup instead.