### PR TITLE
Handle hashes with keys in different orders

### DIFF
--- a/lib/active_record_bulk_insert.rb
+++ b/lib/active_record_bulk_insert.rb
@@ -15,7 +15,7 @@ ActiveRecord::Base.class_eval do
     return [] if attrs.empty?
 
     use_provided_primary_key = options.fetch(:use_provided_primary_key, false)
-    attributes = _resolve_record(attrs.first, options).keys.join(", ")
+    attributes = _resolve_record(attrs.first, options).keys
 
     invalid = []
     if options.fetch(:validate, false) || options.fetch(:validate_with, false)
@@ -24,15 +24,16 @@ ActiveRecord::Base.class_eval do
     end
 
     values_sql = attrs.map do |record|
-      quoted = _resolve_record(record, options).map {|k, v|
-        _bulk_insert_quote(k, v)
+      resolved_record = _resolve_record(record, options)
+      quoted = attributes.map {|k|
+        _bulk_insert_quote(k, resolved_record.fetch(k))
       }
       "(#{quoted.join(', ')})"
     end.join(",")
 
     sql = <<-SQL
       INSERT INTO #{quoted_table_name}
-        (#{attributes})
+        (#{attributes.join(", ")})
       VALUES
         #{values_sql}
     SQL

--- a/spec/sample_record_spec.rb
+++ b/spec/sample_record_spec.rb
@@ -52,6 +52,15 @@ describe SampleRecord do
       end.to_not raise_error
     end
 
+    it "handles multiple records with keys in different orders" do
+      SampleRecord.bulk_insert([{:name => "Foo", :age => 30}, {:age => 30, :name => "Foo"}])
+
+      SampleRecord.all.each do |record|
+        expect(record.name).to eq("Foo")
+        expect(record.age).to eq(30)
+      end
+    end
+
     if ActiveRecord::VERSION::MAJOR >= 4
       context "use_provided_primary_key" do
         it "relies on the DB to provide primary_key if :use_provided_primary_key is false or nil" do


### PR DESCRIPTION
If the records passed to `bulk_insert` have their keys in different orders, the values will be inserted into incorrect columns.

This ensures that the value strings are always built in correct column order.